### PR TITLE
Allow quoting values, so it's possible to start/end values with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ key3 = unintuitive value
 [ anotherSection ]
 key1 = a value
 key2 = yet another value
+key3 = " This value is quoted as we want to begin with a space."
 #...
 ```
 
@@ -19,6 +20,9 @@ Blank lines are skipped, and lines beginning with `#` are considered
 comments to be skipped. It is an error to have a section marker ('[]')
 without a section name. `key = ` lines will set the line to a blank
 value. If no section is given, the default section (`default`).
+
+If you want the value to start or end with spaces, you may quote
+the value, in 'single' or "double" quotes.
 
 Parsing a file can be done with the ParseFile function. It will return
 a `map[string]map[string]string`. For example, if the section `foo` is

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package goconfig
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -120,6 +121,22 @@ func TestWriteConfigFile(t *testing.T) {
 				FailWithError(t, err)
 			}
 		}
+	}
+	fmt.Println("ok")
+}
+
+func TestQuotedValue(t *testing.T) {
+	testFile := "testdata/test.conf"
+	fmt.Printf("[+] validating quoted value... ")
+	cmap, _ := ParseFile(testFile)
+	val := cmap["sectionName"]["key4"]
+	if val != " space at beginning and end " {
+		FailWithError(t, errors.New("Wrong value in double quotes ["+val+"]"))
+	}
+
+	val = cmap["sectionName"]["key5"]
+	if val != " is quoted with single quotes " {
+		FailWithError(t, errors.New("Wrong value in single quotes ["+val+"]"))
 	}
 	fmt.Println("ok")
 }

--- a/testdata/test.conf
+++ b/testdata/test.conf
@@ -4,6 +4,8 @@ key2 = some other value
 # we want to explain the importance and great forethought
 # in this next value.
 key3 = unintuitive value
+key4 = " space at beginning and end "
+key5 = ' is quoted with single quotes '
 
 [ anotherSection ]
 key1 = a value


### PR DESCRIPTION
This commit allows quoting values in the configuration file, so that it's possible to start or end the values with spaces.
